### PR TITLE
Feature: Add option to disable media controls in window previews

### DIFF
--- a/package/contents/config/ConfigAppearance.qml
+++ b/package/contents/config/ConfigAppearance.qml
@@ -391,5 +391,17 @@ ConfigPage {
             text: Wrappers.i18n("Automatically set to Large when in Touch mode")
             font: Kirigami.Theme.smallFont
         }
+
+        Item {
+            Kirigami.FormData.isSection: true
+        }
+
+        CheckBox {
+            id: disableMediaControls
+            Kirigami.FormData.label: Wrappers.i18n("Window Previews:")
+            text: Wrappers.i18n("Disable media controls in window previews")
+            checked: cfg_page.cfg_disableMediaControls
+            onToggled: cfg_page.cfg_disableMediaControls = checked
+        }
     }
 }

--- a/package/contents/config/ConfigPage.qml
+++ b/package/contents/config/ConfigPage.qml
@@ -94,6 +94,8 @@ KCMUtils.SimpleKCM {
     property var cfg_launchersDefault
     property int cfg_middleClickAction
     property int cfg_middleClickActionDefault
+    property bool cfg_disableMediaControls
+    property bool cfg_disableMediaControlsDefault
 
     // --- Task Button Appearance ---
     property bool cfg_buttonColorize

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -342,6 +342,10 @@
         <label>Icon zoom animation duration</label>
         <tooltip>Duration of the zoom animation in milliseconds</tooltip>
     </entry>
+    <entry name="disableMediaControls" type="Bool">
+      <label>Disables showing media controls in window previews.</label>
+      <default>false</default>
+    </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/ToolTipInstance.qml
+++ b/package/contents/ui/ToolTipInstance.qml
@@ -749,7 +749,7 @@ Item {
 
     readonly property bool showVolumeControls: index !== -1 && pulseAudio.item !== null && audioIndicatorsEnabled && (isPlayingAudio || hasAudioStream)
     
-    property bool controlsAreEffective: showPlayerControls || showVolumeControls
+    property bool controlsAreEffective: !Plasmoid.configuration.disableMediaControls && (showPlayerControls || showVolumeControls)
     property bool delayedControlsActive: false
     
     onControlsAreEffectiveChanged: {


### PR DESCRIPTION
Currently, media controls overlap the bottom half of the preview window, which I personally found pretty annoying and unwanted. So I decided to look into it and add a toggle option that lets you disable them entirely.