### PR TITLE
feat(context-menu): add per-activity pinning submenu for launchers

### DIFF
--- a/package/contents/ui/ContextMenu.qml
+++ b/package/contents/ui/ContextMenu.qml
@@ -68,6 +68,9 @@ PlasmaExtras.Menu {
             if (virtualDesktopsMenuItem.visible) {
                 virtualDesktopsMenuItem._virtualDesktopsMenu.refresh();
             }
+            if (showLauncherInActivitiesItem.visible) {
+                showLauncherInActivitiesItem._activitiesLaunchersMenu.refresh();
+            }
         } else if (status === PlasmaExtras.Menu.Closed) {
             menu.destroy();
         }
@@ -639,42 +642,130 @@ PlasmaExtras.Menu {
     PlasmaExtras.MenuItem {
         id: launcherToggleAction
 
-        visible: visualParent && !get(atm.IsLauncher) && !get(atm.IsStartup) && Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable && !isPinned()
+        visible: visualParent && !get(atm.IsLauncher) && !get(atm.IsStartup) && Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable && (menu.activityInfo.numberOfRunningActivities < 2) && !isPinned() && !doesBelongToCurrentActivity()
 
         enabled: visualParent && get(atm.LauncherUrlWithoutIcon).toString() !== ""
 
         text: Wrappers.i18n("&Pin to Task Manager")
         icon: "window-pin"
 
+        // A launcher is "pinned" if it exists in the TasksModel's launcher list.
+        // We must check the model (not Plasmoid.configuration.launchers), because
+        // activity-scoped entries are serialized as "[uuid]\nurl" and would not
+        // match a plain indexOf() on the raw config list.
         function isPinned(): bool {
-            var url = get(atm.LauncherUrlWithoutIcon).toString();
-            return config.launchers.indexOf(url) !== -1;
+            return menu.tasksModel.launcherPosition(get(atm.LauncherUrlWithoutIcon)) !== -1;
+        }
+
+        // Also hide "Pin to Task Manager" when the app is already pinned to
+        // the current activity (single-activity case).
+        function doesBelongToCurrentActivity(): bool {
+            return menu.tasksModel.launcherActivities(get(atm.LauncherUrlWithoutIcon)).some(activity => activity === menu.activityInfo.currentActivity || activity === menu.activityInfo.nullUuid);
         }
 
         onClicked: {
-            var launchers = config.launchers.slice();
-            var url = get(atm.LauncherUrlWithoutIcon).toString();
-            if (launchers.indexOf(url) === -1) {
-                launchers.push(url);
-                config.launchers = launchers;
+            // Go through the model so the serialized form (including the
+            // activity assignment) is persisted to Plasmoid.configuration.launchers
+            // automatically via onLauncherListChanged in main.qml.
+            menu.tasksModel.requestAddLauncher(get(atm.LauncherUrlWithoutIcon));
+        }
+    }
+
+    PlasmaExtras.MenuItem {
+        id: showLauncherInActivitiesItem
+
+        text: Wrappers.i18n("&Pin to Task Manager")
+        icon: "window-pin"
+
+        // Unlike launcherToggleAction this also shows for pinned shortcuts
+        // (IsLauncher), letting the user re-pin them to other activities.
+        visible: visualParent && get(atm.IsStartup) !== true && Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable && (menu.activityInfo.numberOfRunningActivities >= 2)
+
+        readonly property Connections activitiesLaunchersMenuConnections: Connections {
+            target: menu.activityInfo
+
+            function onNumberOfRunningActivitiesChanged(): void {
+                showLauncherInActivitiesItem._activitiesLaunchersMenu["refresh"]();
+            }
+        }
+
+        readonly property PlasmaExtras.Menu _activitiesLaunchersMenu: PlasmaExtras.Menu {
+            id: activitiesLaunchersMenu
+
+            visualParent: showLauncherInActivitiesItem.action
+
+            function refresh(): void {
+                clearMenuItems();
+
+                if (menu.visualParent === null) {
+                    return;
+                }
+
+                // The model reports a launcher's activity assignments as UUIDs
+                // (launcherActivities()); the all-zeros nullUuid means "all
+                // activities". The model persists them as "[uuid1,uuid2]\nurl"
+                // entries in the launchers config.
+                const createNewItem = (id, title, iconName, url, activities) => {
+                    var result = menu.newMenuItem(activitiesLaunchersMenu);
+                    result.text = title;
+                    result.icon = iconName;
+
+                    result.visible = true;
+                    result.checkable = true;
+
+                    result.checked = activities.some(activity => activity === id);
+
+                    // For checkable menu items "clicked" fires after the check
+                    // state has already toggled, so result.checked is the NEW
+                    // state: checked -> pin to this activity, unchecked -> unpin.
+                    result.clicked.connect(() => {
+                        if (result.checked) {
+                            menu.tasksModel.requestAddLauncherToActivity(url, id);
+                        } else {
+                            menu.tasksModel.requestRemoveLauncherFromActivity(url, id);
+                        }
+                    });
+
+                    return result;
+                };
+
+                const url = menu.get(atm.LauncherUrlWithoutIcon);
+
+                const activities = menu.tasksModel.launcherActivities(url);
+
+                createNewItem(menu.activityInfo.nullUuid, Wrappers.i18n("On All Activities"), "", url, activities);
+
+                if (menu.activityInfo.numberOfRunningActivities <= 1) {
+                    return;
+                }
+
+                createNewItem(menu.activityInfo.currentActivity, Wrappers.i18n("On The Current Activity"), menu.activityInfo.activityIcon(menu.activityInfo.currentActivity), url, activities);
+
+                menu.newSeparator(activitiesLaunchersMenu);
+
+                const runningActivities = menu.activityInfo.runningActivities();
+                for (let i = 0; i < runningActivities.length; ++i) {
+                    const activityId = runningActivities[i];
+                    createNewItem(activityId, menu.activityInfo.activityName(activityId), menu.activityInfo.activityIcon(activityId), url, activities);
+                }
+            }
+
+            Component.onCompleted: {
+                menu.visualParentChanged.connect(refresh);
+                refresh();
             }
         }
     }
 
     PlasmaExtras.MenuItem {
-        visible: visualParent && get(atm.IsStartup) !== true && Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable && (get(atm.IsLauncher) || launcherToggleAction.isPinned())
+        visible: visualParent && get(atm.IsStartup) !== true && Plasmoid.immutability !== PlasmaCore.Types.SystemImmutable && !launcherToggleAction.visible && menu.activityInfo.numberOfRunningActivities < 2
 
         text: Wrappers.i18n("Unpin from Task Manager")
         icon: "window-unpin"
 
         onClicked: {
-            var launchers = config.launchers.slice();
-            var url = get(atm.LauncherUrlWithoutIcon).toString();
-            var index = launchers.indexOf(url);
-            if (index !== -1) {
-                launchers.splice(index, 1);
-                config.launchers = launchers;
-            }
+            // Go through the model so the config list stays in sync.
+            menu.tasksModel.requestRemoveLauncher(get(atm.LauncherUrlWithoutIcon));
         }
     }
 

--- a/tools/translate/ReadMe.md
+++ b/tools/translate/ReadMe.md
@@ -26,8 +26,8 @@ Everything is managed via `make` from the **root directory of the project**:
 ## Status
 | Locale   | Lines   | % Done |
 |----------|---------|--------|
-| Template | 262     |        |
-| nl       | 60/262  | 22%    |
-| pt_BR    | 63/262  | 24%    |
-| ru       | 262/262 | 100%   |
-| zh_CN    | 60/262  | 22%    |
+| Template | 264     |        |
+| nl       | 60/264  | 22%    |
+| pt_BR    | 63/264  | 23%    |
+| ru       | 262/264 | 99%    |
+| zh_CN    | 60/264  | 22%    |

--- a/tools/translate/languages/nl.po
+++ b/tools/translate/languages/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fancytasks\n"
 "Report-Msgid-Bugs-To: https://github.com/daydve/FancyTasksNG\n"
-"POT-Creation-Date: 2026-08-12 01:11+0300\n"
+"POT-Creation-Date: 2026-08-30 21:59+0200\n"
 "PO-Revision-Date: 2023-07-13 22:27+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -970,6 +970,14 @@ msgstr "Verplaatsen naar %1"
 #: package/contents/ui/ContextMenu.qml
 msgid "&Pin to Task Manager"
 msgstr "Vastma&ken aan takenbeheer"
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On All Activities"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On The Current Activity"
+msgstr ""
 
 #: package/contents/ui/ContextMenu.qml
 msgid "Unpin from Task Manager"

--- a/tools/translate/languages/pt_BR.po
+++ b/tools/translate/languages/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Fancy Tasks\n"
 "Report-Msgid-Bugs-To: https://github.com/daydve/FancyTasksNG\n"
-"POT-Creation-Date: 2026-08-12 01:11+0300\n"
+"POT-Creation-Date: 2026-08-30 21:59+0200\n"
 "PO-Revision-Date: 2023-09-21 16:18-0300\n"
 "Last-Translator:  Douglas Guimarães <<dg2003gh@gmail.com>>\n"
 "Language-Team: \n"
@@ -970,6 +970,14 @@ msgstr "Mover para %1"
 #: package/contents/ui/ContextMenu.qml
 msgid "&Pin to Task Manager"
 msgstr "&Fixar no gerenciador de tarefas"
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On All Activities"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On The Current Activity"
+msgstr ""
 
 #: package/contents/ui/ContextMenu.qml
 msgid "Unpin from Task Manager"

--- a/tools/translate/languages/ru.po
+++ b/tools/translate/languages/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Fancy Tasks\n"
 "Report-Msgid-Bugs-To: https://github.com/daydve/FancyTasksNG\n"
-"POT-Creation-Date: 2026-08-12 01:11+0300\n"
+"POT-Creation-Date: 2026-08-30 21:59+0200\n"
 "PO-Revision-Date: 2025-12-22 13:00+0300\n"
 "Last-Translator: Vitaliy Elin <daydve@smbit/.pro>\n"
 "Language-Team: Russian\n"
@@ -972,6 +972,14 @@ msgstr "Переместить в %1"
 #: package/contents/ui/ContextMenu.qml
 msgid "&Pin to Task Manager"
 msgstr "&Закрепить в панели задач"
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On All Activities"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On The Current Activity"
+msgstr ""
 
 #: package/contents/ui/ContextMenu.qml
 msgid "Unpin from Task Manager"

--- a/tools/translate/languages/template.pot
+++ b/tools/translate/languages/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fancytasksng\n"
 "Report-Msgid-Bugs-To: https://github.com/daydve/FancyTasksNG\n"
-"POT-Creation-Date: 2026-08-12 01:11+0300\n"
+"POT-Creation-Date: 2026-08-30 21:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -970,6 +970,14 @@ msgstr ""
 
 #: package/contents/ui/ContextMenu.qml
 msgid "&Pin to Task Manager"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On All Activities"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On The Current Activity"
 msgstr ""
 
 #: package/contents/ui/ContextMenu.qml

--- a/tools/translate/languages/zh_CN.po
+++ b/tools/translate/languages/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fancytasks\n"
 "Report-Msgid-Bugs-To: https://github.com/daydve/FancyTasksNG\n"
-"POT-Creation-Date: 2026-08-12 01:11+0300\n"
+"POT-Creation-Date: 2026-08-30 21:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -970,6 +970,14 @@ msgstr "移动到%1"
 #: package/contents/ui/ContextMenu.qml
 msgid "&Pin to Task Manager"
 msgstr "固定到任务栏"
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On All Activities"
+msgstr ""
+
+#: package/contents/ui/ContextMenu.qml
+msgid "On The Current Activity"
+msgstr ""
 
 #: package/contents/ui/ContextMenu.qml
 msgid "Unpin from Task Manager"


### PR DESCRIPTION
   Fixes #50

   Ports the stock Task Manager's "Pin to Task Manager" activity submenu:

   - With 1 activity: "Pin to Task Manager" now goes through `TasksModel.requestAddLauncher()` so the model and the `launchers` config stay in sync.
   - With 2+ activities: the item shows a submenu (On All Activities / On The Current Activity / one checkable entry per activity) via the existing `requestAddLauncherToActivity()` / `requestRemoveLauncherFromActivity()` backend. It also appears for already-pinned shortcuts.
   - Pinned-state checks now use `TasksModel.launcherPosition()`, which also recognizes activity-scoped entries (`[uuid]\nurl`).

Same behavior as plasma-desktop's taskmanager ContextMenu.qml.
Translation template regenerated via `tools/extract_messages.sh` (2 new strings).
